### PR TITLE
0.6.3 - Internal changes to Multipoints, perimeters and more

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,4 +1,11 @@
 Release History
+
+0.6.3 (July 7, 2019)
+++++++++++++++++++++
+* Multipoints, and Perimeters internally use tuples instead of GridPoints. This yields a performance improvement.
+* Summit/SaddleContainers have @property to just return multiPoint members.
+* Base/Gridpoints now have factory method for creating object to/from tuple.
+
 0.6.2 (January 21, 2019)
 ++++++++++++++++++++++++
 * Added docs for readthedocs.io

--- a/pyprom/__init__.py
+++ b/pyprom/__init__.py
@@ -6,7 +6,7 @@ the LICENSE file that accompanies it.
 
 PyProm: This library includes tools for surface network analysis.
 """
-version_info = (0, 6, 2)
+version_info = (0, 6, 3)
 __name__ = 'pyProm'
 __doc__ = 'A python surface network analysis script'
 __author__ = 'Marc Howes'

--- a/pyprom/domain.py
+++ b/pyprom/domain.py
@@ -31,6 +31,8 @@ from .lib.containers.walkpath import WalkPath
 from .lib.locations.gridpoint import GridPoint
 from .lib.logic.basin_saddle_finder import BasinSaddleFinder
 
+from .lib.constants import DOMAIN_EXTENSION
+
 
 class Domain:
     """
@@ -147,6 +149,9 @@ class Domain:
          :class:`pyprom.lib.containers.linker.Linker`
         """
         filename = os.path.expanduser(filename)
+        if not filename.endswith(DOMAIN_EXTENSION):
+            filename += DOMAIN_EXTENSION
+
         self.logger.info("Writing Domain Dataset to {}.".format(filename))
         outgoing = gzip.open(filename, 'wb', 5)
         # ^^ ('filename', 'read/write mode', compression level)
@@ -454,8 +459,10 @@ class Domain:
             # Higher than current highest neighbor? Then this is
             # the new candidate.
             if elevation > currentHigh:
-                candidate = GridPoint(x, y, elevation)
+                candidate = (x, y, elevation)
                 currentHigh = elevation
+        if candidate:
+            candidate = GridPoint.from_tuple(candidate)
         return candidate, None, explored, orderedExploredPoints
 
     def detect_basin_saddles(self):

--- a/pyprom/domain.py
+++ b/pyprom/domain.py
@@ -429,13 +429,13 @@ class Domain:
         startingElevation = point.elevation
         lastElevation = point.elevation
         currentHigh = lastElevation
-        candidates = None
+        candidate = None
 
         neighbors = self.datamap.iterateDiagonal(point.x, point.y)
         for x, y, elevation in neighbors:
             if elevation is None:
                 continue
-            # Oh fuck no, we've got an equalHeightBlob. Better check that out.
+            # Oh no, we've got an equalHeightBlob. Better check that out.
             if elevation == startingElevation:
                 multipoint, _ = equalHeightBlob(self.datamap, x, y, elevation)
                 # Find all perimeter points higher than
@@ -454,9 +454,9 @@ class Domain:
             # Higher than current highest neighbor? Then this is
             # the new candidate.
             if elevation > currentHigh:
-                candidates = GridPoint(x, y, elevation)
+                candidate = GridPoint(x, y, elevation)
                 currentHigh = elevation
-        return candidates, None, explored, orderedExploredPoints
+        return candidate, None, explored, orderedExploredPoints
 
     def detect_basin_saddles(self):
         """

--- a/pyprom/domain.py
+++ b/pyprom/domain.py
@@ -296,7 +296,7 @@ class Domain:
         for point in self.summits.points:
             if point.multiPoint:
                 for mp in point.multiPoint.points:
-                    summitHash[mp.x][mp.y] = point
+                    summitHash[mp[0]][mp[1]] = point
             else:
                 x, y = self.datamap.latlong_to_xy(point.latitude,
                                                   point.longitude)
@@ -334,7 +334,7 @@ class Domain:
         for point in self.summits.points:
             if point.multiPoint:
                 for mp in point.multiPoint.points:
-                    summitHash[mp.x][mp.y] = point
+                    summitHash[mp[0]][mp[1]] = point
             else:
                 x, y = self.datamap.latlong_to_xy(point.latitude,
                                                   point.longitude)
@@ -446,9 +446,9 @@ class Domain:
                 highNeighbors.sort(key=lambda x: x.elevation, reverse=True)
                 # Mark multipoint components as explored.
                 for mp in multipoint:
-                    explored[mp.x][mp.y] = True
+                    explored[mp[0]][mp[1]] = True
                     orderedExploredPoints.append(
-                        self.datamap.xy_to_latlong(mp.x, mp.y))
+                        self.datamap.xy_to_latlong(mp[0], mp[1]))
                 return highNeighbors.points[0], None,\
                     explored, orderedExploredPoints
             # Higher than current highest neighbor? Then this is

--- a/pyprom/feature_discovery.py
+++ b/pyprom/feature_discovery.py
@@ -24,6 +24,8 @@ from .lib.containers.runoffs import RunoffsContainer
 from .lib.containers.perimeter import Perimeter
 from .lib.logic.equalheight import equalHeightBlob
 
+from .lib.constants import METERS_TO_FEET
+
 
 class AnalyzeData:
     """
@@ -89,7 +91,7 @@ class AnalyzeData:
             x, y = iterator.multi_index
             # core storage is always in metric.
             if self.datamap.unit == "FEET":
-                self.elevation = float(.3048 * iterator[0])
+                self.elevation = float(METERS_TO_FEET * iterator[0])
             else:
                 self.elevation = float(iterator[0])
 

--- a/pyprom/feature_discovery.py
+++ b/pyprom/feature_discovery.py
@@ -188,11 +188,10 @@ class AnalyzeData:
                     not self.explored[_x].get(_y, False):
                 return self.analyze_multipoint(_x, _y, elevation)
 
-            gp = GridPoint(_x, _y, elevation)
             if elevation > self.elevation:
-                shoreSetIndex[_x][_y] = gp
+                shoreSetIndex[_x][_y] = (_x, _y, elevation)
             if self.x_mapEdge.get(_x) or self.y_mapEdge.get(_y):
-                shoreMapEdge.append(gp)
+                shoreMapEdge.append(GridPoint(_x, _y, elevation))
 
         shoreSet = Perimeter(pointIndex=shoreSetIndex,
                              datamap=self.datamap,

--- a/pyprom/feature_discovery.py
+++ b/pyprom/feature_discovery.py
@@ -144,7 +144,7 @@ class AnalyzeData:
         blob, edgePoints = equalHeightBlob(self.datamap, x, y, ptElevation)
         edge = blob.perimeter.mapEdge
         for exemptPoint in blob:
-            self.explored[exemptPoint.x][exemptPoint.y] = True
+            self.explored[exemptPoint[0]][exemptPoint[1]] = True
 
         return self.consolidatedFeatureLogic(x, y, blob.perimeter,
                                              blob, edge, edgePoints)

--- a/pyprom/lib/constants.py
+++ b/pyprom/lib/constants.py
@@ -1,0 +1,18 @@
+"""
+pyProm: Copyright 2018.
+
+This software is distributed under a license that is described in
+the LICENSE file that accompanies it.
+"""
+
+
+DOMAIN_EXTENSION = ".dom"
+
+# Unit Conversion Constants
+
+METERS_TO_FEET = 0.3048
+
+FEET_TO_METERS = 3.280839895
+
+FEET_IN_MILES = 5280
+

--- a/pyprom/lib/containers/multipoint.py
+++ b/pyprom/lib/containers/multipoint.py
@@ -236,7 +236,8 @@ class MultiPoint:
 
         :param point: tuple, or
          :class:`pyprom.lib.locations.base_gridpoint.BaseGridPoint
-        :raises: TypeError if point not of :class:`BaseGridPoint` or tuple
+        :raises: TypeError if point not of
+         :class:`pyprom.lib.locations.base_gridpoint.BaseGridPoint` or tuple
         :raises: Exception if tuple length != 2
         :return: tuple(x,y)
         """

--- a/pyprom/lib/containers/saddles.py
+++ b/pyprom/lib/containers/saddles.py
@@ -174,6 +174,16 @@ class SaddlesContainer(SpotElevationContainer):
         """
         return [x for x in self.points if x.disqualified]
 
+    @property
+    def multipoints(self):
+        """
+        Returns list of all multipoint
+         :class:`pyprom.lib.locations.saddle.Saddle` within container
+
+        :return: list(:class:`pyprom.lib.locations.saddle.Saddle`)
+        """
+        return [pt for pt in self.points if pt.multiPoint]
+
     def __repr__(self):
         """
         :return: String representation of this object

--- a/pyprom/lib/containers/spot_elevation.py
+++ b/pyprom/lib/containers/spot_elevation.py
@@ -10,7 +10,10 @@ type location objects.
 
 from ..locations.summit import Summit
 from ..locations.spot_elevation import isSpotElevation
+from ..constants import METERS_TO_FEET, FEET_IN_MILES
 from .base import _Base
+
+
 from geopy.distance import vincenty
 
 
@@ -98,9 +101,9 @@ class SpotElevationContainer(_Base):
         elif unit in ['kilometers', 'kilometer', 'km']:
             convertedDist = value * 1000
         elif unit in ['feet', 'foot', 'ft']:
-            convertedDist = 0.3048 * value
+            convertedDist = METERS_TO_FEET * value
         elif unit in ['miles', 'mile', 'mi']:
-            convertedDist = 0.3048 * value * 5280
+            convertedDist = METERS_TO_FEET * value * FEET_IN_MILES
         else:
             raise ValueError('No unit value specified')
 

--- a/pyprom/lib/containers/summits.py
+++ b/pyprom/lib/containers/summits.py
@@ -81,6 +81,16 @@ class SummitsContainer(SpotElevationContainer):
 
         return summitsContainer
 
+    @property
+    def multipoints(self):
+        """
+        Returns list of all multipoint
+         :class:`pyprom.lib.locations.summit.Summit` within container
+
+        :return: list(:class:`pyprom.lib.locations.summit.Summit`)
+        """
+        return [pt for pt in self.points if pt.multiPoint]
+
     def __setitem__(self, idx, summit):
         """
         Gives SummitsContainer list like set capabilities

--- a/pyprom/lib/datamap.py
+++ b/pyprom/lib/datamap.py
@@ -8,9 +8,9 @@ This file acts as the glue between the raster data loaded and the logic
 used to analyze the map.
 """
 
-from __future__ import division
-
 import logging
+
+from .constants import METERS_TO_FEET
 
 ARCSEC_DEG = 3600
 ARCMIN_DEG = 60
@@ -55,7 +55,7 @@ class DataMap:
             if 0 <= _x <= self.max_x and \
                0 <= _y <= self.max_y:
                 if self.unit == 'FEET':
-                    yield _x, _y, float(.3048 * self.numpy_map[_x, _y])
+                    yield _x, _y, float(METERS_TO_FEET * self.numpy_map[_x, _y])
                 else:
                     yield _x, _y, float(self.numpy_map[_x, _y])
             else:
@@ -76,7 +76,7 @@ class DataMap:
             if 0 <= _x <= self.max_x and \
                0 <= _y <= self.max_y:
                 if self.unit == 'FEET':
-                    yield _x, _y, float(.3048 * self.numpy_map[_x, _y])
+                    yield _x, _y, float(METERS_TO_FEET * self.numpy_map[_x, _y])
                 else:
                     yield _x, _y, float(self.numpy_map[_x, _y])
             else:
@@ -184,7 +184,7 @@ class ProjectionDataMap(DataMap):
         """
         x, y = self.latlong_to_xy(latitude, longitude)
         if self.unit == 'FEET':
-            return float(.3048 * self.numpy_map[x, y])
+            return float(METERS_TO_FEET * self.numpy_map[x, y])
         else:
             return self.numpy_map[x, y]
 

--- a/pyprom/lib/locations/base_gridpoint.py
+++ b/pyprom/lib/locations/base_gridpoint.py
@@ -27,6 +27,28 @@ class BaseGridPoint:
         self.x = x
         self.y = y
 
+    @classmethod
+    def from_dict(self, baseGridPointDict):
+        """
+        Create this object from dictionary representation
+
+        :param dict baseGridPointDict: dict() representation of this object.
+        :return: BaseGridPoint from dict()
+        :rtype: :class:`BaseGridPoint`
+        """
+        return self(baseGridPointDict['x'],
+                    baseGridPointDict['y'])
+
+    @classmethod
+    def from_tuple(self, tup):
+        """
+        Create this object from tuple representation
+        :param tup:
+        :return: BaseGridPoint from tuple()
+        :rtype: :class:`BaseGridPoint`
+        """
+        return self(tup[0], tup[1])
+
     def to_dict(self):
         """
         Create the dictionary representation of this object.
@@ -36,6 +58,16 @@ class BaseGridPoint:
         """
         return {'x': self.x,
                 'y': self.y}
+
+    def to_tuple(self):
+        """
+        Create the tuple representation of this object.
+
+        :return: tuple() representation of :class:`BaseGridPoint`
+        :rtype: tuple()
+        """
+        return (self.x, self.y)
+
 
     def distance(self, other):
         """

--- a/pyprom/lib/locations/gridpoint.py
+++ b/pyprom/lib/locations/gridpoint.py
@@ -27,14 +27,6 @@ class GridPoint(BaseGridPoint):
         super(GridPoint, self).__init__(x, y)
         self.elevation = elevation
 
-    def to_dict(self):
-        """
-        :return: dict() representation of :class:`GridPoint`
-        """
-        return {'x': self.x,
-                'y': self.y,
-                'elevation': self.elevation}
-
     @classmethod
     def from_dict(self, gridPointDict):
         """
@@ -47,6 +39,30 @@ class GridPoint(BaseGridPoint):
         return self(gridPointDict['x'],
                     gridPointDict['y'],
                     gridPointDict['elevation'])
+
+    @classmethod
+    def from_tuple(self, tup):
+        """
+        Create this object from tuple representation
+        :param tup:
+        :return: GridPoint from tuple()
+        :rtype: :class:`GridPoint`
+        """
+        return self(tup[0], tup[1], tup[2])
+
+    def to_dict(self):
+        """
+        :return: dict() representation of :class:`GridPoint`
+        """
+        return {'x': self.x,
+                'y': self.y,
+                'elevation': self.elevation}
+
+    def to_tuple(self):
+        """
+        :return: tuple() representation of :class:`GridPoint`
+        """
+        return (self.x, self.y, self.elevation)
 
     def toSpotElevation(self, datamap):
         """

--- a/pyprom/lib/logic/basin_saddle_finder.py
+++ b/pyprom/lib/logic/basin_saddle_finder.py
@@ -124,7 +124,6 @@ class BasinSaddleFinder:
         """
         lowest[0].disqualify_self_and_linkers(basinSaddle=True)
         if len(lowest) > 1:
-            print("")
             for saddle in lowest:
                 saddle.basinSaddleAlternatives = lowest.copy()
                 saddle.basinSaddleAlternatives.remove(saddle)

--- a/pyprom/lib/logic/equalheight.py
+++ b/pyprom/lib/logic/equalheight.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from ..locations.gridpoint import GridPoint
 from ..locations.base_gridpoint import BaseGridPoint
 from ..containers.multipoint import MultiPoint
-from ..util import coordinateHashToGridPointList
+from ..util import coordinateHashToXYTupleList
 from ..containers.perimeter import Perimeter
 
 
@@ -71,7 +71,7 @@ def equalHeightBlob(datamap, x, y, elevation):
                         perimeterPointHash[_x][_y] = gp
                     if x_mapEdge.get(_x) or y_mapEdge.get(_y):
                         shoreMapEdge.append(gp)
-    return MultiPoint(coordinateHashToGridPointList(exploredEqualHeight),
+    return MultiPoint(coordinateHashToXYTupleList(exploredEqualHeight),
                       masterGridPoint.elevation, datamap,
                       perimeter=Perimeter(
                           pointIndex=perimeterPointHash,

--- a/pyprom/lib/logic/equalheight.py
+++ b/pyprom/lib/logic/equalheight.py
@@ -28,7 +28,7 @@ def equalHeightBlob(datamap, x, y, elevation):
     :return: MultiPoint Object containing all x,y coordinates and elevation
     :rtype: :class:`pyprom.lib.containers.multipoint.MultiPoint`
     """
-    masterGridPoint = GridPoint(x, y, elevation)
+    masterGridPoint = (x, y, elevation)
     exploredEqualHeight = defaultdict(dict)
     exploredEqualHeight[x][y] = True
     perimeterPointHash = defaultdict(dict)
@@ -45,17 +45,17 @@ def equalHeightBlob(datamap, x, y, elevation):
     edge = False
     while toBeAnalyzed:
         gridPoint = toBeAnalyzed.pop()
-        neighbors = datamap.iterateDiagonal(gridPoint.x, gridPoint.y)
+        neighbors = datamap.iterateDiagonal(gridPoint[0], gridPoint[1])
         # Determine if edge or not.
         if not edge:
-            if x_mapEdge.get(gridPoint.x) or y_mapEdge.get(gridPoint.y):
+            if x_mapEdge.get(gridPoint[0]) or y_mapEdge.get(gridPoint[1]):
                 edge = True
         for _x, _y, elevation in neighbors:
             if elevation is None:
                 continue
-            elif elevation == masterGridPoint.elevation and\
+            elif elevation == masterGridPoint[2] and\
                     not exploredEqualHeight[_x].get(_y, False):
-                branch = GridPoint(_x, _y, elevation)
+                branch = (_x, _y, elevation)
                 exploredEqualHeight[_x][_y] = True
                 if x_mapEdge.get(_x) or y_mapEdge.get(_y):
                     multipointEdges.append(BaseGridPoint(_x, y))
@@ -64,15 +64,14 @@ def equalHeightBlob(datamap, x, y, elevation):
             # a perimeter point. Only keep track of edgepoints
             # higher!
 
-            elif elevation != masterGridPoint.elevation:
+            elif elevation != masterGridPoint[2]:
                 if not perimeterPointHash[_x].get(_y, False):
-                    gp = GridPoint(_x, _y, elevation)
-                    if elevation > masterGridPoint.elevation:
-                        perimeterPointHash[_x][_y] = gp
+                    if elevation > masterGridPoint[2]:
+                        perimeterPointHash[_x][_y] = (_x, _y, elevation)
                     if x_mapEdge.get(_x) or y_mapEdge.get(_y):
-                        shoreMapEdge.append(gp)
+                        shoreMapEdge.append(GridPoint(_x, _y, elevation))
     return MultiPoint(coordinateHashToXYTupleList(exploredEqualHeight),
-                      masterGridPoint.elevation, datamap,
+                      masterGridPoint[2], datamap,
                       perimeter=Perimeter(
                           pointIndex=perimeterPointHash,
                           datamap=datamap,

--- a/pyprom/lib/util.py
+++ b/pyprom/lib/util.py
@@ -63,6 +63,17 @@ def coordinateHashToGridPointList(coordinateHash):
             for x, _y in coordinateHash.items() for y, _ in _y.items()]
 
 
+def coordinateHashToXYTupleList(coordinateHash):
+    """
+    Converts a coordinateHash to a list of tuples
+
+    :param dict coordinateHash: a hash using
+     {x1:[y1:True,y2:True..],x1:[y1:True,y2:True..]} format
+    :return: list of (x,y) tuples.
+    """
+    return [(x, y) for x, _y in coordinateHash.items() for y, _ in _y.items()]
+
+
 def compressRepetetiveChars(string):
     """
     Accepts String like "HHLHHHLL" and removes continuous redundant chars

--- a/pyprom/tests/containers/testMultipointContainer.py
+++ b/pyprom/tests/containers/testMultipointContainer.py
@@ -76,7 +76,8 @@ class MultipointTests(unittest.TestCase):
         """
         Ensure __setattr__ works as expected.
         """
-        multipoint = MultiPoint([self.bgp11], 100, self.datamap)
+        multipoint = MultiPoint([], 100, self.datamap)
+        multipoint.append(self.bgp11)
         self.assertEqual(len(multipoint), 1)
         multipoint[0] = self.bgp22
         self.assertEqual(multipoint[0], self.bgp22)
@@ -85,7 +86,8 @@ class MultipointTests(unittest.TestCase):
         """
         Ensure __setattr__ Disallows Non BaseGridpoints to be set.
         """
-        multipoint = MultiPoint([self.bgp11], 100, self.datamap)
+        multipoint = MultiPoint([], 100, self.datamap)
+        multipoint.append(self.bgp11)
         self.assertEqual(len(multipoint), 1)
         with self.assertRaises(TypeError):
             multipoint[0] = "wtf"
@@ -94,7 +96,8 @@ class MultipointTests(unittest.TestCase):
         """
         Ensure __getattr__ works as expected.
         """
-        multipoint = MultiPoint([self.bgp11], 100, self.datamap)
+        multipoint = MultiPoint([], 100, self.datamap)
+        multipoint.append(self.bgp11)
         self.assertEqual(len(multipoint), 1)
         self.assertEqual(multipoint[0], self.bgp11)
 
@@ -102,7 +105,8 @@ class MultipointTests(unittest.TestCase):
         """
         Ensure adding string to Multipoint fails.
         """
-        multipoint = MultiPoint([self.bgp11], 100, self.datamap)
+        multipoint = MultiPoint([], 100, self.datamap)
+        multipoint.append(self.bgp11)
         with self.assertRaises(TypeError):
             multipoint.append("stuff")
 
@@ -110,7 +114,8 @@ class MultipointTests(unittest.TestCase):
         """
         Ensure adding GridPoint to SummitsContainer succeeds.
         """
-        multipoint = MultiPoint([self.bgp11], 100, self.datamap)
+        multipoint = MultiPoint([], 100, self.datamap)
+        multipoint.append(self.bgp11)
         multipoint.append(self.bgp22)
         self.assertEqual(len(multipoint), 2)
 
@@ -118,9 +123,12 @@ class MultipointTests(unittest.TestCase):
         """
         Ensure __eq__ works as expected.
         """
-        multipoint = MultiPoint([self.bgp11], 100, self.datamap)
-        multipoint2 = MultiPoint([self.bgp11], 100, self.datamap)
-        multipoint3 = MultiPoint([self.bgp22], 100, self.datamap)
+        multipoint = MultiPoint([], 100, self.datamap)
+        multipoint.append(self.bgp11)
+        multipoint2 = MultiPoint([], 100, self.datamap)
+        multipoint2.append(self.bgp11)
+        multipoint3 = MultiPoint([], 100, self.datamap)
+        multipoint3.append(self.bgp22)
 
         self.assertEqual(multipoint, multipoint2)
         test = multipoint2 == multipoint3
@@ -130,9 +138,12 @@ class MultipointTests(unittest.TestCase):
         """
         Ensure __ne__ works as expected.
         """
-        multipoint = MultiPoint([self.bgp11], 100, self.datamap)
-        multipoint2 = MultiPoint([self.bgp11], 100, self.datamap)
-        multipoint3 = MultiPoint([self.bgp22], 100, self.datamap)
+        multipoint = MultiPoint([], 100, self.datamap)
+        multipoint.append(self.bgp11)
+        multipoint2 = MultiPoint([], 100, self.datamap)
+        multipoint2.append(self.bgp11)
+        multipoint3 = MultiPoint([], 100, self.datamap)
+        multipoint3.append(self.bgp22)
 
         self.assertNotEqual(multipoint, multipoint3)
         test = multipoint != multipoint2
@@ -195,7 +206,7 @@ class MultipointTests(unittest.TestCase):
         points = []
         for x in range(100, 110):
             for y in range(200, 210):
-                points.append(BaseGridPoint(x, y))
+                points.append((x, y))
         mp = MultiPoint(points, 100, self.datamap)
 
         # Inside the MP
@@ -259,7 +270,7 @@ class MultipointTests(unittest.TestCase):
         points = []
         for x in range(100, 110):
             for y in range(200, 210):
-                points.append(BaseGridPoint(x, y))
+                points.append((x, y))
         mp = MultiPoint(points, 100, self.datamap)
 
         # Inside the MP

--- a/pyprom/tests/containers/testPerimeter.py
+++ b/pyprom/tests/containers/testPerimeter.py
@@ -25,15 +25,37 @@ class PerimeterTests(unittest.TestCase):
         cls.datamap = cls.datafile.datamap
         # contigous Perimeter
         cls.perimeterI = defaultdict(dict)
-        cls.perimeterI[1][1] = cls.p11 = GridPoint(1, 1, 553)
-        cls.perimeterI[1][2] = cls.p12 = GridPoint(1, 2, 554)
-        cls.perimeterI[1][3] = cls.p13 = GridPoint(1, 3, 554)
-        cls.perimeterI[1][4] = cls.p14 = GridPoint(1, 4, 553)
-        cls.perimeterI[2][4] = cls.p24 = GridPoint(2, 4, 555)
-        cls.perimeterI[2][5] = cls.p25 = GridPoint(2, 5, 554)
-        cls.perimeterI[2][6] = cls.p26 = GridPoint(2, 6, 553)
+        cls.perimeterI[1][1] = cls.p11 = (1, 1, 553)
+        cls.perimeterI[1][2] = cls.p12 = (1, 2, 554)
+        cls.perimeterI[1][3] = cls.p13 = (1, 3, 554)
+        cls.perimeterI[1][4] = cls.p14 = (1, 4, 553)
+        cls.perimeterI[2][4] = cls.p24 = (2, 4, 555)
+        cls.perimeterI[2][5] = cls.p25 = (2, 5, 554)
+        cls.perimeterI[2][6] = cls.p26 = (2, 6, 553)
         cls.perimeter = Perimeter(pointIndex=cls.perimeterI,
                                   datamap=cls.datamap)
+
+    def testPerimeterBothIndexAndList(self):
+        """
+        Ensure passing in a pointList and pointIndex raises exception
+        """
+        with self.assertRaises(Exception):
+            Perimeter(pointIndex=self.perimeterI, pointList=[(1, 1)], datamap=self.datamap)
+
+    def testPerimeterListBuildsIndex(self):
+        """
+        Ensure passing in a pointList produces a pointIndex
+        """
+        perm = Perimeter(pointList=self.perimeter.points, datamap=self.datamap)
+        self.assertDictEqual(perm.pointIndex['1'], self.perimeter.pointIndex['1'])
+        self.assertDictEqual(perm.pointIndex['2'], self.perimeter.pointIndex['2'])
+
+    def testPerimeterIndexBuildsList(self):
+        """
+        Ensure passing in a pointList produces a pointIndex
+        """
+        perm = Perimeter(pointIndex=self.perimeter.pointIndex, datamap=self.datamap)
+        self.assertEqual(perm.points, self.perimeter.points)
 
     def testPerimeterIterNeighborDiagonal(self):
         """
@@ -121,9 +143,9 @@ class PerimeterTests(unittest.TestCase):
                       datamap=self.datamap)
         highEdges = perimeterDiscontigous.findHighEdges(552)
         self.assertEqual(2, len(highEdges))
-        self.assertEqual(highEdges[0].points, [self.p11, self.p12])
-        self.assertEqual(highEdges[1].points, [self.p14, self.p24,
-                                               self.p25, self.p26])
+        self.assertEqual(highEdges[0].points, [GridPoint.from_tuple(self.p11), GridPoint.from_tuple(self.p12)])
+        self.assertEqual(highEdges[1].points, [GridPoint.from_tuple(self.p14), GridPoint.from_tuple(self.p24),
+                                               GridPoint.from_tuple(self.p25), GridPoint.from_tuple(self.p26)])
 
     def testPerimeterFindHighEdgesOrthogonallyDiscontigous(self):
         """
@@ -269,7 +291,7 @@ class PerimeterTests(unittest.TestCase):
         Ensure From Dict works as expected.
         """
         self.perimeter.mapEdge = True
-        self.perimeter.mapEdgePoints = [self.p11]
+        self.perimeter.mapEdgePoints = [GridPoint.from_tuple(self.p11)]
 
         perimeterDict = self.perimeter.to_dict()
 

--- a/pyprom/tests/containers/testSaddlesContainer.py
+++ b/pyprom/tests/containers/testSaddlesContainer.py
@@ -127,6 +127,16 @@ class SaddlesContainerTests(unittest.TestCase):
         container = SaddlesContainer([s1, s2, sd3, sd4])
         self.assertEqual(container.disqualified, [sd3, sd4])
 
+    def testSaddlesContainerMultiPoint(self):
+        """
+        Ensure multipoint() returns all multipoint Summits
+        """
+        s1 = Saddle(1, 1, 1)
+        s1.multiPoint = ["bogus_but_ok_for_test"]
+        s2 = Saddle(2, 2, 2)
+        container = SaddlesContainer([s1, s2])
+        self.assertEqual(container.multipoints, [s1])
+
 
 class SaddlesContainerRebuildTests(unittest.TestCase):
     """

--- a/pyprom/tests/containers/testSummitsContainer.py
+++ b/pyprom/tests/containers/testSummitsContainer.py
@@ -119,3 +119,13 @@ class SummitsContainerTests(unittest.TestCase):
         self.assertEqual(newSummit.edgeEffect, summit.edgeEffect)
         self.assertEqual(newSummit.edgePoints, summit.edgePoints)
         self.assertEqual(newSummit.id, summit.id)
+
+    def testSummitsContainerMultiPoint(self):
+        """
+        Ensure multipoint() returns all multipoint Summits
+        """
+        s1 = Summit(1, 1, 1)
+        s1.multiPoint = ["bogus_but_ok_for_test"]
+        s2 = Summit(2, 2, 2)
+        container = SummitsContainer([s1, s2])
+        self.assertEqual(container.multipoints, [s1])

--- a/pyprom/tests/locations/testBaseGridPoint.py
+++ b/pyprom/tests/locations/testBaseGridPoint.py
@@ -27,6 +27,29 @@ class BaseGridPointTests(unittest.TestCase):
         test = BaseGridPoint(1, 2)
         self.assertEqual(test.to_dict(), {'x': 1, 'y': 2})
 
+    def testBaseGridPointFromDict(self):
+        """
+        Ensure from_dict() works as expected
+        """
+        bgp = BaseGridPoint(1, 2)
+        bgp_dict = {"x": 1, "y": 2, "elevation": 3}
+        self.assertEqual(BaseGridPoint.from_dict(bgp_dict), bgp)
+
+    def testBaseGridPointToTuple(self):
+        """
+        Ensure to_tuple() returns expected results.
+        """
+        test = BaseGridPoint(1, 2)
+        self.assertEqual(test.to_tuple(), (1, 2))
+
+    def testBaseGridPointFromTuple(self):
+        """
+        Ensure from_tuple() works as expected
+        """
+        bgp = BaseGridPoint(1, 2)
+        bgp_tuple = (1, 2)
+        self.assertEqual(BaseGridPoint.from_tuple(bgp_tuple), bgp)
+
     def testBaseGridPointDistance(self):
         """
         Ensure distance() returns expected results.

--- a/pyprom/tests/locations/testGridPoint.py
+++ b/pyprom/tests/locations/testGridPoint.py
@@ -41,6 +41,38 @@ class GridPointTests(unittest.TestCase):
         gp_dict = gp.to_dict()
         self.assertEqual(gp_dict, {"x": 1, "y": 2, "elevation": 3})
 
+    def testGridPointToTuple(self):
+        """
+        Ensure to_tuple() works as expected
+        """
+        gp = GridPoint(1, 2, 3)
+        gp_tuple = gp.to_tuple()
+        self.assertEqual(gp_tuple, (1, 2, 3))
+
+    def testGridPointFromDict(self):
+        """
+        Ensure from_dict() works as expected
+        """
+        gp = GridPoint(1, 2, 3)
+        gp_dict = {"x": 1, "y": 2, "elevation": 3}
+        self.assertEqual(GridPoint.from_dict(gp_dict), gp)
+
+    def testGridPointFromTuple(self):
+        """
+        Ensure from_tuple() works as expected
+        """
+        gp = GridPoint(1, 2, 3)
+        gp_tuple = (1, 2, 3)
+        self.assertEqual(GridPoint.from_tuple(gp_tuple), gp)
+
+    def testGridPointToTuple(self):
+        """
+        Ensure to_tuple() works as expected
+        """
+        gp = GridPoint(1, 2, 3)
+        gp_tuple = gp.to_tuple()
+        self.assertEqual(gp_tuple, (1, 2, 3))
+
     def testGridPointToSpotElevation(self):
         """
         Ensure toSpotElevation works as expected

--- a/pyprom/tests/util/helpers.py
+++ b/pyprom/tests/util/helpers.py
@@ -7,7 +7,6 @@ the LICENSE file that accompanies it.
 
 from pyprom.lib.containers.gridpoint import GridPointContainer
 from pyprom.lib.containers.multipoint import MultiPoint
-from pyprom.lib.locations.base_gridpoint import BaseGridPoint
 from pyprom.lib.locations.gridpoint import GridPoint
 from pyprom.lib.locations.saddle import Saddle
 
@@ -32,11 +31,11 @@ def generate_MultiPoint(x, y, xSpan, ySpan,
     for xx in range(x, x + xSpan):
         for yy in range(y, y + ySpan):
             # leave these ones out, they're our islands.
-            mpBlock.append(BaseGridPoint(xx, yy))
+            mpBlock.append((xx, yy))
     mp = MultiPoint(mpBlock, elevation, datamap)
     for excluded in excludeBGPC:
         for point in excluded.points:
-            mp.points.remove(point)
+            mp.points.remove(point.to_tuple())
     return mp
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy == 1.15.0
+numpy == 1.16.4
 gdal
 fastkml
 shapely


### PR DESCRIPTION
This PR removes GridPoints as the internal storage for Perimeters and Multipoints. These objects are created frequently, and are costly to create/store. instead, we can use tuples which work just as well in most cases and are far lighter.

Using tuples also saves us time/space when serializing to cbor
